### PR TITLE
minor tweak to even out spacing in footer

### DIFF
--- a/layout/_partial/footer.ejs
+++ b/layout/_partial/footer.ejs
@@ -46,7 +46,8 @@
   <p>
     <span><%- config.title %> &copy; <%= (new Date()).getFullYear() %></span>
     <% if(config.footer !== null) { %>
-      <span class="split">|</span><span><%- config.footer || theme.footer %></span>
+      <span class="split">|</span>
+      <span><%- config.footer || theme.footer %></span>
     <% } %>
   </p>
 </footer>


### PR DESCRIPTION
Added newline after pipe character in footer to even out spacing.

Before

![before](https://cloud.githubusercontent.com/assets/123952/21583451/508978be-d04f-11e6-8fe3-014b156b5371.png)

After

![after](https://cloud.githubusercontent.com/assets/123952/21583453/57ef293c-d04f-11e6-997f-e2abd77831ae.png)