### PR TITLE
Remove zepto

### DIFF
--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -1,5 +1,4 @@
 <!-- scripts -->
-<script src="//cdn.bootcss.com/zepto/1.2.0/zepto.min.js"></script>
 <%- js('js/app.js') %>
 <%if (config.disqus_shortname){ %>
 <script>

--- a/source/js/app.js
+++ b/source/js/app.js
@@ -23,15 +23,19 @@ var appDaily = {
     return false;
   },
   bindToggleButton: function() {
-    var $btn = $('.menu-toggle');
-    var $nav = $('.navbar');
+    var btn = document.querySelector('.menu-toggle');
+    var nav = document.querySelector('.navbar');
 
-    $btn.on('click', function() {
-      $nav.toggleClass('show-force');
-    })
+    btn.addEventListener('click', function() {
+      var c = nav.getAttribute('class') || '';
+
+      if (c.indexOf('show-force') !== -1) {
+        nav.setAttribute('class', c.replace(/show-force/, '').trim());
+      } else {
+        nav.setAttribute('class', (c + ' show-force').trim());
+      }
+    });
   }
 };
 
-$(document).ready(function() {
-  appDaily.bindToggleButton();
-});
+appDaily.bindToggleButton();


### PR DESCRIPTION
Replaced zepto code with plain dom code so that zepto can be removed completely. This was the only place I could find that uses it.

If you're okay with dropping ie9 support, I could add another commit that shortens the listener to

```js
btn.addEventListener('click', function() {
  // ie10+
  nav.classList.toggle('show-force');
});
```