### PR TITLE
fix logo link error

### DIFF
--- a/layout/_partial/nav.ejs
+++ b/layout/_partial/nav.ejs
@@ -1,7 +1,7 @@
 <header class="site-header">
   <div class="header-inside">
     <div class="logo">
-      <a href="/" rel="home">
+      <a href="<%= url_for() %>" rel="home">
         <% if (config.logo || theme.logo) { %>
         <img src="<%- config.logo || theme.logo %>" alt="<%- config.title %>" height="60">
         <% } %>


### PR DESCRIPTION
Link for logo was set to “/”. However, when the site is put in a
subdirectory, the link should be “/subdirectory”.

“url_for()” always return the correct url for Home.