### PR TITLE
Change the default value of `lang` attribute

### DIFF
--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="zh-CN">
+<html lang="<%= config.language ? config.language : 'en' %>">
 
 <!-- Head tag -->
 <%- partial('_partial/head') %>


### PR DESCRIPTION
I changed the default value of `lang` attribute in `<html>` tag from "zh-CN" to "en" if it was not set in config file.